### PR TITLE
Also suppress Wself-move under gcc 13

### DIFF
--- a/test/shared_lock_test.cpp
+++ b/test/shared_lock_test.cpp
@@ -23,7 +23,7 @@
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wself-move"
 #endif
-#if __GNUC__ >= 13
+#if defined(__GNUC__) && __GNUC__ >= 13
 #pragma GCC diagnostic ignored "-Wself-move"
 #endif
 

--- a/test/shared_lock_test.cpp
+++ b/test/shared_lock_test.cpp
@@ -23,6 +23,9 @@
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wself-move"
 #endif
+#if __GNUC__ >= 13
+#pragma GCC diagnostic ignored "-Wself-move"
+#endif
 
 struct invalid_lock_use: public std::runtime_error
 {


### PR DESCRIPTION
Compiling with gcc 13.1.0:

   ../libs/compat/test/shared_lock_test.cpp: In function 'void {anonymous}::move_assignment()':
   ../libs/compat/test/shared_lock_test.cpp:378:10: error: moving 'lock' of type '{anonymous}::shared_lock_type' {aka 'boost::compat::shared_lock<dummy_lock>'} to itself [-Werror=self-move]
     378 |     lock = std::move( lock );
         |     ~~~~~^~~~~~~~~~~~~~~~~~~
   ../libs/compat/test/shared_lock_test.cpp:378:10: note: remove 'std::move' call
   cc1plus: all warnings being treated as errors