### PR TITLE
`function_ref` should not always reference qualify parameters

### DIFF
--- a/include/boost/compat/function_ref.hpp
+++ b/include/boost/compat/function_ref.hpp
@@ -131,7 +131,7 @@ public:
   function_ref_base(const function_ref_base&) noexcept = default;
   function_ref_base& operator=(const function_ref_base&) noexcept = default;
 
-  R operator()(Args&&... args) const noexcept(NoEx) { return this->invoke_(thunk_, std::forward<Args>(args)...); }
+  R operator()(Args... args) const noexcept(NoEx) { return this->invoke_(thunk_, std::forward<Args>(args)...); }
 };
 
 } // namespace detail


### PR DESCRIPTION
By accepting `Args&&...`, a function that accepts its arguments by value is required to accept only rvalues. Instead, we should accept `Args...` (the exact argument types listed in the signature), which allows by-value parameters to copy from lvalue arguments.