### PR TITLE
fix lvalue parameter passing

### DIFF
--- a/include/boost/compat/function_ref.hpp
+++ b/include/boost/compat/function_ref.hpp
@@ -131,7 +131,7 @@ public:
   function_ref_base(const function_ref_base&) noexcept = default;
   function_ref_base& operator=(const function_ref_base&) noexcept = default;
 
-  R operator()(Args&&... args) const noexcept(NoEx) { return this->invoke_(thunk_, std::forward<Args>(args)...); }
+  R operator()(Args... args) const noexcept(NoEx) { return this->invoke_(thunk_, std::forward<Args>(args)...); }
 };
 
 } // namespace detail

--- a/test/function_ref_fn_test.cpp
+++ b/test/function_ref_fn_test.cpp
@@ -98,8 +98,9 @@ int main() {
 
   // f1
   {
+    int x = 1;
     compat::function_ref<int(int)> fv1(f1);
-    BOOST_TEST_EQ(fv1(1), 1);
+    BOOST_TEST_EQ(fv1(x), 1);
 
     compat::function_ref<int(int) const> fv2(f1);
     BOOST_TEST_EQ(fv2(1), 1);

--- a/test/function_ref_mfn_test.cpp
+++ b/test/function_ref_mfn_test.cpp
@@ -41,8 +41,9 @@ int main() {
     compat::function_ref<int(F1&)> fn1(compat::nontype_t<&F1::m1>{});
     BOOST_TEST_EQ(fn1(f1), 0);
 
+    int x = 2;
     compat::function_ref<int(F1&, int)> fn2(compat::nontype_t<&F1::m2>{});
-    BOOST_TEST_EQ(fn2(f1, 2), 12);
+    BOOST_TEST_EQ(fn2(f1, x), 12);
 
     compat::function_ref<int(F1&, int, int)> fn3(compat::nontype_t<&F1::m3>{});
     BOOST_TEST_EQ(fn3(f1, 2, 3), 123);

--- a/test/function_ref_obj_test.cpp
+++ b/test/function_ref_obj_test.cpp
@@ -65,8 +65,8 @@ int main() {
       BOOST_TEST_TRAIT_FALSE((std::is_constructible<compat::function_ref<S1>, F1 const&&>));
 
       compat::function_ref<S2> fv2(f);
-
-      BOOST_TEST_EQ(fv2(1), 1);
+      int x = 1;
+      BOOST_TEST_EQ(fv2(x), 1);
 
       BOOST_TEST_TRAIT_FALSE((std::is_constructible<compat::function_ref<S2>, F1 const>));
       BOOST_TEST_TRAIT_FALSE((std::is_constructible<compat::function_ref<S2>, F1 const&>));


### PR DESCRIPTION
Closes PR #15

Includes the same fix but includes updated tests.

Thanks to @davidstone for noticing this and including a fix.
