### PR TITLE
Qualify calls to placement new

### DIFF
--- a/include/boost/compat/move_only_function.hpp
+++ b/include/boost/compat/move_only_function.hpp
@@ -397,7 +397,7 @@ struct move_only_function_base
             case op_type::move:
             {
                 VT* p = static_cast<VT*>( src->addr() );
-                new(s.addr()) VT( std::move( *p ) );
+                ::new( s.addr() ) VT( std::move( *p ) );
                 // destruct the element here because move construction will leave the container empty
                 // outside of this function
                 p->~VT();
@@ -446,7 +446,7 @@ struct move_only_function_base
     template<class VT, class ...CArgs>
     void init_object( std::true_type /* use_sbo */, CArgs&& ...args )
     {
-        new( s_.addr() ) VT( std::forward<CArgs>( args )... );
+        ::new( s_.addr() ) VT( std::forward<CArgs>( args )... );
         invoke_ = &mo_invoke_local_holder<RQ, Const, NoEx, VT, R, Args...>::invoke_local;
         manager_ = &manage_local<VT>;
     }

--- a/test/move_only_function_test.cpp
+++ b/test/move_only_function_test.cpp
@@ -102,6 +102,9 @@ struct callable
     {
         return *p_ + x;
     }
+
+    // Should never be called, as this should always fit into the small buffer.
+    void* operator new(std::size_t) { throw 1234; }
 };
 
 struct noex_callable
@@ -122,6 +125,9 @@ struct noex_callable
     {
         return *p_ + x;
     }
+
+    // Should never be called, as this should always fit into the small buffer.
+    void* operator new(std::size_t) { throw 1234; }
 };
 
 struct large_callable


### PR DESCRIPTION
Fix a compilation failure when SBO-friendly Callables provide their own overloads for operator new.